### PR TITLE
search word on double-click + persist page state via URL hash

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,12 @@
   directory). This should open Aard2 web UI page
   (http://localhost:8013) in the default system browser.
 
+  To make the web server available for the entire home/work network add `-Dslobber.host=0.0.0.0`, e.g:
+
+   #+BEGIN_SRC sh
+  java -Dslobber.browse=true -Dslobber.host=0.0.0.0 -jar aard2-web-0.8.jar ~/Downloads/*.slob
+   #+END_SRC
+
   To start the web server on a different port, set system
   property /slobber.port/. For example, to start on port 8014:
 

--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
   directory). This should open Aard2 web UI page
   (http://localhost:8013) in the default system browser.
 
-  To make the web server available for the entire home/work network add /-Dslobber.host=0.0.0.0/, e.g:
+  To make the web server available for the LAN network add /-Dslobber.host=0.0.0.0/, e.g:
 
    #+BEGIN_SRC sh
   java -Dslobber.browse=true -Dslobber.host=0.0.0.0 -jar aard2-web-0.8.jar ~/Downloads/*.slob

--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
   directory). This should open Aard2 web UI page
   (http://localhost:8013) in the default system browser.
 
-  To make the web server available for the entire home/work network add `-Dslobber.host=0.0.0.0`, e.g:
+  To make the web server available for the entire home/work network add /-Dslobber.host=0.0.0.0/, e.g:
 
    #+BEGIN_SRC sh
   java -Dslobber.browse=true -Dslobber.host=0.0.0.0 -jar aard2-web-0.8.jar ~/Downloads/*.slob

--- a/src/script.js
+++ b/src/script.js
@@ -16,6 +16,10 @@ $(function () {
       if (contentLocation.href === "about:blank") {
         $contentHeader.hide();
       } else {
+        var url = new URL(contentLocation.href);
+        url.searchParams.set('q', $word.val());
+        window.top.location.hash = url.pathname + url.search;
+        history.pushState("", "", window.top.location.href);
         var i,
           slobId,
           lookupKey,
@@ -43,6 +47,17 @@ $(function () {
           $("#header-title").text(contentLocation.href);
         }
         $contentHeader.show();
+        $content.contents().find('body').dblclick(function(e) {
+          var selectedWord = $content.contents()[0].getSelection().toString().trim();
+          if (selectedWord) {
+            $word.val(selectedWord);
+            doLookup(true);
+            $content.attr('src', "");
+            setTimeout(function(){
+              $content.attr('src', $('#lookup-result li:first-child a').attr('href'));
+            }, 500);
+          }
+        });
       }
     } catch (x) {
       console.warn(x);
@@ -114,6 +129,14 @@ $(function () {
       $lookupResult.append($ul);
     });
   };
+
+  if (window.top.location.hash) {
+    var itemUrl = window.top.location.hash.slice(1);
+    var params = new URLSearchParams(itemUrl);
+    $word.val(params.get('q'));
+    doLookup();
+    $("#content").attr("src", itemUrl);
+  }
 
   var onInputChange = function () {
     if (scheduledLookupID) {

--- a/src/script.js
+++ b/src/script.js
@@ -50,12 +50,11 @@ $(function () {
         $content.contents().find('body').dblclick(function(e) {
           var selectedWord = $content.contents()[0].getSelection().toString().trim();
           if (selectedWord) {
+            var $link = $("<a>").attr("href", selectedWord);
+            $(e.target).append($link);
+            $link[0].click();
             $word.val(selectedWord);
             doLookup(true);
-            $content.attr('src', "");
-            setTimeout(function(){
-              $content.attr('src', $('#lookup-result li:first-child a').attr('href'));
-            }, 500);
           }
         });
       }

--- a/src/script.js
+++ b/src/script.js
@@ -17,7 +17,9 @@ $(function () {
         $contentHeader.hide();
       } else {
         var url = new URL(contentLocation.href);
-        url.searchParams.set('q', $word.val());
+        if ($word.val()) {
+          url.searchParams.set('q', $word.val());
+        }
         window.top.location.hash = url.pathname + url.search;
         history.pushState("", "", window.top.location.href);
         var i,
@@ -119,21 +121,26 @@ $(function () {
         var $a = $("<a>")
           .append($label)
           .append($dictLabel)
-          .attr("href", item.url)
+          .attr("href", item.url.slice(0,-1) + "&q=" + item.label)
           .attr("target", "content");
         $li.append($a);
         $ul.append($li);
         return true;
       });
       $lookupResult.append($ul);
+      if (!$content.attr('src')) {
+        $content.attr('src', $ul.find('li:first-child a').attr('href'));
+      }
     });
   };
 
   if (window.top.location.hash) {
     var itemUrl = window.top.location.hash.slice(1);
-    var params = new URLSearchParams(itemUrl);
-    $word.val(params.get('q'));
-    doLookup();
+    var q = new URLSearchParams(new URL(itemUrl, 'http://_').search).get('q');
+    if (q) {
+      $word.val(q);
+      doLookup();
+    }
     $("#content").attr("src", itemUrl);
   }
 


### PR DESCRIPTION
1. Store current dictionary and lookup word in the top page URL hash to allow persisting state on page refresh.

Allows reopening a specific article with the lookup word via a top frame URL like 

- http://127.0.0.1:8013/#/slob/c52148ef-0ac7-47cf-bd0f-c503552ebdd7/awake?blob=155-10&q=awake

With this change clicking refresh in the browser will allow the page state to survive, and the original search and definition to be shown rather than a reset to original empty state. Moreover, this allows bookmarking definitions in a specific dictionary. 

2. Double-clicking a word in the content frame initiates a lookup ~~and opening 1st result in the content frame~~ and searching the double-clicked word in the current dictionary.

3. After a lookup open first entry in content frame